### PR TITLE
upgrade kustomize and lint

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -117,16 +117,16 @@ INFORMER_GEN = $(LOCALBIN)/informer-gen
 LISTER_GEN = $(LOCALBIN)/lister-gen
 GOLANG_CI_LINT = $(LOCALBIN)/golangci-lint
 
-## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.9.2
-GOLANG_CI_LINT_VERSION ?= v1.46.2
 
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+## Tool Versions
+KUSTOMIZE_VERSION ?= v4.5.6
+CONTROLLER_TOOLS_VERSION ?= v0.9.2
+GOLANG_CI_LINT_VERSION ?= v1.48.0
+
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
-	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v4@$(KUSTOMIZE_VERSION)OMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -126,7 +126,7 @@ GOLANG_CI_LINT_VERSION ?= v1.48.0
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v4@$(KUSTOMIZE_VERSION)OMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v4@$(KUSTOMIZE_VERSION)
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.


### PR DESCRIPTION
Upgrades Kustomize to V4 and golanci to 1.48.0

Necessary to build on M1 Mac Books as Kutomize V3 has no ARM support