### PR TITLE
Fix/Standardize kustomization Rendering

### DIFF
--- a/operator/config/certmanager/kustomization.yaml
+++ b/operator/config/certmanager/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
 resources:
 - certificate.yaml
 

--- a/operator/config/default/manager_config_patch.yaml
+++ b/operator/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: manager
+  name: controller-manager
   namespace: system
 spec:
   template:

--- a/operator/config/istio/kustomization.yaml
+++ b/operator/config/istio/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
 resources:
 - gateway.yaml
 - virtual_service.yaml

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -6,7 +6,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: manager
+  name: controller-manager
   namespace: system
 spec:
   replicas: 1

--- a/operator/config/prometheus/kustomization.yaml
+++ b/operator/config/prometheus/kustomization.yaml
@@ -1,2 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
 resources:
 - monitor.yaml

--- a/operator/config/webhook/kustomization.yaml
+++ b/operator/config/webhook/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
 resources:
 - manifests.yaml
 - service.yaml


### PR DESCRIPTION
Fixes 2 rendering issues:

- Some Components are not defined as components and will only work as resources. This has been fixed
- The deployment of the controller-manager was called `manager` which caused it to not be renamed during rendering