### PR TITLE
Fix declarative manifest caching that was not invalidated

### DIFF
--- a/operator/controllers/manifest_controller.go
+++ b/operator/controllers/manifest_controller.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kyma-project/module-manager/operator/pkg/cache"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
@@ -407,7 +408,7 @@ func (r *ManifestReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Mana
 	r.RestConfig = mgr.GetConfig()
 
 	// initialize new cluster cache
-	r.CacheManager = NewCacheManager()
+	r.CacheManager = cache.NewCacheManager()
 
 	// register listener component
 	runnableListener, eventChannel := listener.RegisterListenerComponent(

--- a/operator/pkg/cache/client_cache_manager.go
+++ b/operator/pkg/cache/client_cache_manager.go
@@ -1,4 +1,4 @@
-package controllers
+package cache
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/operator/pkg/manifest/renderer_cache_test.go
+++ b/operator/pkg/manifest/renderer_cache_test.go
@@ -186,26 +186,26 @@ var _ = Describe("given manifest with a helm repo", Ordered, func() {
 			// fourth call for operations for same parent resource and configuration.
 			verifyCacheEntries(testCaseFn(testResourceName, parentCacheKey, chartFlagsVariantOne, rendererCache))
 			// check set count
-			Expect(setProcessorCount).To(Equal(2)) // new processor + new flags
+			Expect(setProcessorCount).To(Equal(1)) // new processor
 			Expect(setConfigCount).To(Equal(1))    // new flags
 
 			// fifth call for operations for SAME parent and DIFFERENT configuration.
 			// Configuration contains both types.SetFlags and types.ConfigFlags as part of types.ChartFlags
 			verifyCacheEntries(testCaseFn(testResourceName, parentCacheKey, chartFlagsVariantTwo, rendererCache))
 			// check set count
-			Expect(setProcessorCount).To(Equal(3)) // ^above + updated flags
+			Expect(setProcessorCount).To(Equal(2)) // ^above
 			Expect(setConfigCount).To(Equal(2))    // ^above + updated flags
 
 			// sixth call for operations for SAME parent, DIFFERENT resource, SAME configuration.
 			verifyCacheEntries(testCaseFn(testResourceName2, parentCacheKey, chartFlagsVariantOne, rendererCache))
 			// check set count
-			Expect(setProcessorCount).To(Equal(4)) // ^above + flags of new resource
+			Expect(setProcessorCount).To(Equal(3)) // ^above
 			Expect(setConfigCount).To(Equal(3))    // ^above + flags of new resource
 
 			// seventh call for operations for a resource and new parent and configuration.
 			verifyCacheEntries(testCaseFn(testResourceName3, parentCacheKey2, chartFlagsVariantOne, rendererCache))
 			// check set count
-			Expect(setProcessorCount).To(Equal(6)) // ^above + new parent + new flags
+			Expect(setProcessorCount).To(Equal(4)) // ^above + new parent
 			Expect(setConfigCount).To(Equal(4))    // ^above + new flags
 		},
 		[]TableEntry{


### PR DESCRIPTION
Fixes https://github.com/kyma-project/module-manager/issues/94

Changes proposed:

- Introduce default cache key fallback for cluster cache based on resource instead of label for declarative case
- Use ClusterCache in declarative reconciler to cache operations and reduce memory and cpu consumption