### PR TITLE
feat: pointer of installinfo and postrun hooks

### DIFF
--- a/controllers/workers.go
+++ b/controllers/workers.go
@@ -33,7 +33,7 @@ func NewManifestWorkers(logger logr.Logger, workersConcurrentManifests int) *Man
 }
 
 func (mw *ManifestWorkerPool) StartWorkers(ctx context.Context, jobChan <-chan OperationRequest,
-	handlerFn func(manifestTypes.InstallInfo, internalTypes.Mode, logr.Logger) *internalTypes.InstallResponse,
+	handlerFn func(*manifestTypes.InstallInfo, internalTypes.Mode, logr.Logger) *internalTypes.InstallResponse,
 ) {
 	for worker := 1; worker <= mw.GetWorkerPoolSize(); worker++ {
 		go func(ctx context.Context, workerId int, deployJob <-chan OperationRequest) {

--- a/internal/pkg/custom/verify.go
+++ b/internal/pkg/custom/verify.go
@@ -23,13 +23,13 @@ type Resource struct {
 }
 
 func (r *Resource) DefaultFn(context.Context, *unstructured.Unstructured, logr.Logger,
-	types.ClusterInfo,
+	*types.ClusterInfo,
 ) (bool, error) {
 	return true, nil
 }
 
 func (r *Resource) CheckFn(ctx context.Context, manifestObj *unstructured.Unstructured, logger logr.Logger,
-	clusterInfo types.ClusterInfo,
+	clusterInfo *types.ClusterInfo,
 ) (bool, error) {
 	// if manifest resource is in deleting state - validate check
 	if !manifestObj.GetDeletionTimestamp().IsZero() {

--- a/internal/pkg/prepare/deploy.go
+++ b/internal/pkg/prepare/deploy.go
@@ -31,7 +31,7 @@ const configReadError = "reading install %s resulted in an error for " + v1alpha
 // each representing an installation artifact.
 func GetInstallInfos(ctx context.Context, manifestObj *v1alpha1.Manifest, defaultClusterInfo types.ClusterInfo,
 	flags internalTypes.ReconcileFlagConfig, processorCache types.RendererCache,
-) ([]types.InstallInfo, error) {
+) ([]*types.InstallInfo, error) {
 	namespacedName := client.ObjectKeyFromObject(manifestObj)
 
 	// extract config
@@ -80,8 +80,8 @@ func GetInstallInfos(ctx context.Context, manifestObj *v1alpha1.Manifest, defaul
 
 	// parse installs
 	baseDeployInfo := types.InstallInfo{
-		ClusterInfo: clusterInfo,
-		ResourceInfo: types.ResourceInfo{
+		ClusterInfo: &clusterInfo,
+		ResourceInfo: &types.ResourceInfo{
 			Crds:            crds,
 			BaseResource:    &unstructured.Unstructured{Object: manifestObjMetadata},
 			CustomResources: []*unstructured.Unstructured{},
@@ -101,7 +101,7 @@ func GetInstallInfos(ctx context.Context, manifestObj *v1alpha1.Manifest, defaul
 		baseDeployInfo.CustomResources = append(baseDeployInfo.CustomResources, &manifestObj.Spec.Resource)
 	}
 
-	return parseInstallations(manifestObj, flags.Codec, configs, baseDeployInfo, flags.InsecureRegistry)
+	return parseInstallations(manifestObj, flags.Codec, configs, &baseDeployInfo, flags.InsecureRegistry)
 }
 
 func getDestinationConfigAndClient(ctx context.Context, defaultClusterInfo types.ClusterInfo,
@@ -162,10 +162,10 @@ func parseInstallConfigs(decodedConfig interface{}) ([]interface{}, error) {
 }
 
 func parseInstallations(manifestObj *v1alpha1.Manifest, codec *types.Codec,
-	configs []interface{}, baseDeployInfo types.InstallInfo, insecureRegistry bool,
-) ([]types.InstallInfo, error) {
+	configs []interface{}, baseDeployInfo *types.InstallInfo, insecureRegistry bool,
+) ([]*types.InstallInfo, error) {
 	namespacedName := client.ObjectKeyFromObject(manifestObj)
-	deployInfos := make([]types.InstallInfo, 0)
+	deployInfos := make([]*types.InstallInfo, 0)
 
 	for _, install := range manifestObj.Spec.Installs {
 		deployInfo := baseDeployInfo

--- a/pkg/applier/ssa.go
+++ b/pkg/applier/ssa.go
@@ -37,7 +37,7 @@ func NewSSAApplier(clients *client.SingletonClients, logger logr.Logger) *SetApp
 	}
 }
 
-func (s *SetApplier) Apply(deployInfo types.InstallInfo, objects *types.ManifestResources,
+func (s *SetApplier) Apply(deployInfo *types.InstallInfo, objects *types.ManifestResources,
 	namespace string,
 ) (bool, error) {
 	// Populate the namespace on any namespace-scoped objects
@@ -67,7 +67,7 @@ func (s *SetApplier) Apply(deployInfo types.InstallInfo, objects *types.Manifest
 	return expectedLength == len(results), nil
 }
 
-func (s *SetApplier) Delete(deployInfo types.InstallInfo, objects *types.ManifestResources,
+func (s *SetApplier) Delete(deployInfo *types.InstallInfo, objects *types.ManifestResources,
 	namespace string,
 ) (bool, error) {
 	// Populate the namespace on any namespace-scoped objects
@@ -140,7 +140,7 @@ func (s *SetApplier) adjustNs(objects *types.ManifestResources, namespace string
 }
 
 func (s *SetApplier) execute(
-	deployInfo types.InstallInfo,
+	deployInfo *types.InstallInfo,
 	objects []*unstructured.Unstructured,
 ) ([]*unstructured.Unstructured, error) {
 	appliedObjects := make([]*unstructured.Unstructured, 0)

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -76,7 +76,7 @@ type SingletonClients struct {
 	unstructuredRESTClientCache map[string]resource.RESTClient
 }
 
-func NewSingletonClients(info types.ClusterInfo, logger logr.Logger) (*SingletonClients, error) {
+func NewSingletonClients(info *types.ClusterInfo, logger logr.Logger) (*SingletonClients, error) {
 	if err := setKubernetesDefaults(info.Config); err != nil {
 		return nil, err
 	}

--- a/pkg/declarative/options.go
+++ b/pkg/declarative/options.go
@@ -53,3 +53,20 @@ func WithFinalizer(finalizer string) ReconcilerOption {
 		return allOptions
 	}
 }
+
+// WithPostRun adds run hooks after installation/uninstallation or consistency checks.
+func WithPostRun(runs ...types.PostRun) ReconcilerOption {
+	return func(allOptions manifestOptions) manifestOptions {
+		allOptions.postRuns = append(allOptions.postRuns, runs...)
+		return allOptions
+	}
+}
+
+func With(option ...ReconcilerOption) ReconcilerOption {
+	return func(allOptions manifestOptions) manifestOptions {
+		for i := range option {
+			allOptions = option[i](allOptions)
+		}
+		return allOptions
+	}
+}

--- a/pkg/declarative/reconciler.go
+++ b/pkg/declarative/reconciler.go
@@ -42,6 +42,7 @@ type manifestOptions struct {
 	verify           bool
 	resourceLabels   map[string]string
 	objectTransforms []types.ObjectTransform
+	postRuns         []types.PostRun
 	manifestResolver types.ManifestResolver
 	finalizer        string
 }
@@ -188,14 +189,19 @@ func (r *ManifestReconciler) HandleProcessingState(ctx context.Context, objectIn
 	if err != nil {
 		return err
 	}
-
-	ready, err := manifest.InstallChart(logger, installInfo, r.options.objectTransforms,
-		r.cacheManager.GetRendererCache())
+	ready, err := manifest.InstallChart(manifest.OperationOptions{
+		Logger:             logger,
+		InstallInfo:        installInfo,
+		ResourceTransforms: r.options.objectTransforms,
+		PostRuns:           r.options.postRuns,
+		Cache:              r.cacheManager.GetRendererCache(),
+	})
 	if err != nil {
 		logger.Error(nil, fmt.Sprintf("error while installing resource %s %s",
 			client.ObjectKeyFromObject(objectInstance), err.Error()))
 		return r.setStatusForObjectInstance(ctx, objectInstance, status.WithState(types.StateError))
 	}
+
 	if ready {
 		return r.setStatusForObjectInstance(ctx, objectInstance, status.WithState(types.StateReady))
 	}
@@ -236,8 +242,13 @@ func (r *ManifestReconciler) HandleDeletingState(ctx context.Context, objectInst
 		return err
 	}
 
-	readyToBeDeleted, err := manifest.UninstallChart(logger, installInfo, r.options.objectTransforms,
-		r.cacheManager.GetRendererCache())
+	readyToBeDeleted, err := manifest.UninstallChart(manifest.OperationOptions{
+		Logger:             logger,
+		InstallInfo:        installInfo,
+		ResourceTransforms: r.options.objectTransforms,
+		PostRuns:           r.options.postRuns,
+		Cache:              r.cacheManager.GetRendererCache(),
+	})
 	if err != nil {
 		logger.Error(err, fmt.Sprintf("error while deleting resource %s", client.ObjectKeyFromObject(objectInstance)))
 		status.State = types.StateError
@@ -276,8 +287,13 @@ func (r *ManifestReconciler) HandleReadyState(ctx context.Context, objectInstanc
 	}
 
 	// verify installed resources
-	ready, err := manifest.ConsistencyCheck(logger, installInfo, r.options.objectTransforms,
-		r.cacheManager.GetRendererCache())
+	ready, err := manifest.ConsistencyCheck(manifest.OperationOptions{
+		Logger:             logger,
+		InstallInfo:        installInfo,
+		ResourceTransforms: r.options.objectTransforms,
+		PostRuns:           r.options.postRuns,
+		Cache:              r.cacheManager.GetRendererCache(),
+	})
 
 	// update only if resources not ready OR an error occurred during chart verification
 	if err != nil {
@@ -292,37 +308,37 @@ func (r *ManifestReconciler) HandleReadyState(ctx context.Context, objectInstanc
 
 func (r *ManifestReconciler) prepareInstallInfo(ctx context.Context, objectInstance types.BaseCustomObject,
 	installSpec types.InstallationSpec, releaseName string,
-) (types.InstallInfo, error) {
-	unstructuredObj := &unstructured.Unstructured{}
+) (*types.InstallInfo, error) {
+	obj := &unstructured.Unstructured{}
 	var err error
 	switch typedObject := objectInstance.(type) {
 	case types.CustomObject:
-		unstructuredObj.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(typedObject)
+		obj.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(typedObject)
 		if err != nil {
-			return types.InstallInfo{}, err
+			return &types.InstallInfo{}, err
 		}
 	case *unstructured.Unstructured:
-		unstructuredObj = typedObject
+		obj = typedObject
 	default:
-		return types.InstallInfo{}, getTypeError(client.ObjectKeyFromObject(objectInstance).String())
+		return &types.InstallInfo{}, getTypeError(client.ObjectKeyFromObject(objectInstance).String())
 	}
 
-	return types.InstallInfo{
+	return &types.InstallInfo{
 		Ctx: ctx,
 		ChartInfo: &types.ChartInfo{
 			ChartPath:   installSpec.ChartPath,
 			ReleaseName: releaseName,
 			Flags:       installSpec.ChartFlags,
 		},
-		ClusterInfo: types.ClusterInfo{
+		ClusterInfo: &types.ClusterInfo{
 			// destination cluster rest config
 			Config: r.mgr.GetConfig(),
 			// destination cluster rest client
 			Client: r.mgr.GetClient(),
 		},
-		ResourceInfo: types.ResourceInfo{
+		ResourceInfo: &types.ResourceInfo{
 			// base operator resource to be passed for custom checks
-			BaseResource: unstructuredObj,
+			BaseResource: obj,
 		},
 		CheckReadyStates: r.options.verify,
 	}, nil
@@ -334,6 +350,7 @@ func (r *ManifestReconciler) applyOptions(opts ...ReconcilerOption) error {
 		verify:           false,
 		resourceLabels:   make(map[string]string, 0),
 		objectTransforms: []types.ObjectTransform{},
+		postRuns:         []types.PostRun{},
 	}
 
 	for _, opt := range opts {

--- a/pkg/manifest/kustomize_processor.go
+++ b/pkg/manifest/kustomize_processor.go
@@ -44,7 +44,7 @@ func NewKustomizeProcessor(
 }
 
 // GetRawManifest returns processed resource manifest using kustomize client.
-func (k *kustomize) GetRawManifest(deployInfo types.InstallInfo) *types.ParsedFile {
+func (k *kustomize) GetRawManifest(deployInfo *types.InstallInfo) *types.ParsedFile {
 	opts := krusty.MakeDefaultOptions()
 	kustomizer := krusty.MakeKustomizer(opts)
 
@@ -73,8 +73,8 @@ func (k *kustomize) GetRawManifest(deployInfo types.InstallInfo) *types.ParsedFi
 }
 
 // Install transforms and applies the kustomize manifest using server side apply.
-func (k *kustomize) Install(manifest string, deployInfo types.InstallInfo,
-	transforms []types.ObjectTransform,
+func (k *kustomize) Install(manifest string, deployInfo *types.InstallInfo,
+	transforms []types.ObjectTransform, _ []types.PostRun,
 ) (bool, error) {
 	// transform
 	objects, err := util.Transform(deployInfo.Ctx, manifest, deployInfo.BaseResource, transforms)
@@ -87,8 +87,8 @@ func (k *kustomize) Install(manifest string, deployInfo types.InstallInfo,
 }
 
 // Uninstall transforms and deletes kustomize based manifest using dynamic client.
-func (k *kustomize) Uninstall(manifest string, deployInfo types.InstallInfo,
-	transforms []types.ObjectTransform,
+func (k *kustomize) Uninstall(manifest string, deployInfo *types.InstallInfo,
+	transforms []types.ObjectTransform, _ []types.PostRun,
 ) (bool, error) {
 	// transform
 	objects, err := util.Transform(deployInfo.Ctx, manifest, deployInfo.BaseResource, transforms)
@@ -105,14 +105,14 @@ func (k *kustomize) Uninstall(manifest string, deployInfo types.InstallInfo,
 }
 
 // IsConsistent indicates if kustomize installation is consistent with the desired manifest resources.
-func (k *kustomize) IsConsistent(manifest string, deployInfo types.InstallInfo,
-	transforms []types.ObjectTransform,
+func (k *kustomize) IsConsistent(manifest string, deployInfo *types.InstallInfo,
+	transforms []types.ObjectTransform, postRuns []types.PostRun,
 ) (bool, error) {
 	// TODO evaluate a better consistency check
-	return k.Install(manifest, deployInfo, transforms)
+	return k.Install(manifest, deployInfo, transforms, postRuns)
 }
 
-func (k *kustomize) InvalidateConfigAndRenderedManifest(_ types.InstallInfo, _ uint32) (uint32, error) {
+func (k *kustomize) InvalidateConfigAndRenderedManifest(_ *types.InstallInfo, _ uint32) (uint32, error) {
 	// TODO implement invalidation logic
 	return 0, nil
 }

--- a/pkg/manifest/renderer_cache_test.go
+++ b/pkg/manifest/renderer_cache_test.go
@@ -43,8 +43,8 @@ var (
 	}
 )
 
-func getDeployInfo(resourceName, parentCacheKey, chartPath, url string, flags types.ChartFlags) types.InstallInfo {
-	return types.InstallInfo{
+func getInstallInfo(resourceName, parentCacheKey, chartPath, url string, flags types.ChartFlags) *types.InstallInfo {
+	return &types.InstallInfo{
 		ChartInfo: &types.ChartInfo{
 			ChartPath: chartPath,
 			URL:       url,
@@ -52,10 +52,10 @@ func getDeployInfo(resourceName, parentCacheKey, chartPath, url string, flags ty
 			Flags:     flags,
 			ChartName: "someChartName",
 		},
-		ClusterInfo: types.ClusterInfo{
+		ClusterInfo: &types.ClusterInfo{
 			Config: &rest.Config{},
 		},
-		ResourceInfo: types.ResourceInfo{
+		ResourceInfo: &types.ResourceInfo{
 			BaseResource: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
@@ -75,8 +75,10 @@ func remoteHelm() func(resourceName string, parentKey string, flags types.ChartF
 ) (string, string, uint32) {
 	return func(resourceName string, parentKey string, flags types.ChartFlags, cache types.RendererCache,
 	) (string, string, uint32) {
-		_, err := manifest.NewOperations(logger, getDeployInfo(resourceName, parentKey, "",
-			"https://helm.nginx.com/stable", flags), nil, cache)
+		_, err := manifest.NewOperations(manifest.OperationOptions{
+			Logger: logger, InstallInfo: getInstallInfo(resourceName, parentKey, "",
+				"https://helm.nginx.com/stable", flags), Cache: cache,
+		})
 		Expect(err).ShouldNot(HaveOccurred())
 		flagsHash, err := util.CalculateHash(flags)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -88,8 +90,12 @@ func localHelm() func(resourceName string, parentKey string, flags types.ChartFl
 ) (string, string, uint32) {
 	return func(resourceName string, parentKey string, flags types.ChartFlags, cache types.RendererCache,
 	) (string, string, uint32) {
-		_, err := manifest.NewOperations(logger, getDeployInfo(resourceName, parentKey,
-			"../test_samples/helm", "", flags), nil, cache)
+		_, err := manifest.NewOperations(manifest.OperationOptions{
+			Logger: logger,
+			InstallInfo: getInstallInfo(resourceName, parentKey,
+				"../test_samples/helm", "", flags),
+			Cache: cache,
+		})
 		Expect(err).ShouldNot(HaveOccurred())
 		flagsHash, err := util.CalculateHash(flags)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/resource/operations.go
+++ b/pkg/resource/operations.go
@@ -50,7 +50,7 @@ func getDirContent(filePath string) ([]fs.DirEntry, error) {
 	return dirEntries, err
 }
 
-func GetChartKind(deployInfo types.InstallInfo) (ChartKind, error) {
+func GetChartKind(deployInfo *types.InstallInfo) (ChartKind, error) {
 	// URLs are not verified at this state
 	if deployInfo.URL != "" {
 		// URL without RepoName is expected for Kustomize

--- a/pkg/types/applier.go
+++ b/pkg/types/applier.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Applier interface {
-	Apply(deployInfo InstallInfo, objects *ManifestResources, namespace string) (bool, error)
+	Apply(deployInfo *InstallInfo, objects *ManifestResources, namespace string) (bool, error)
 }
 
 type ApplierOptions struct {

--- a/pkg/types/check_fn.go
+++ b/pkg/types/check_fn.go
@@ -8,9 +8,9 @@ import (
 	"github.com/go-logr/logr"
 )
 
-type CheckFnType func(context.Context, *unstructured.Unstructured, logr.Logger, ClusterInfo) (bool, error)
+type CheckFnType func(context.Context, *unstructured.Unstructured, logr.Logger, *ClusterInfo) (bool, error)
 
 type Check interface {
-	CheckFn(context.Context, *unstructured.Unstructured, logr.Logger, ClusterInfo) (bool, error)
-	DefaultFn(context.Context, *unstructured.Unstructured, logr.Logger, ClusterInfo) (bool, error)
+	CheckFn(context.Context, *unstructured.Unstructured, logr.Logger, *ClusterInfo) (bool, error)
+	DefaultFn(context.Context, *unstructured.Unstructured, logr.Logger, *ClusterInfo) (bool, error)
 }

--- a/pkg/types/declaritive.go
+++ b/pkg/types/declaritive.go
@@ -5,6 +5,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type CustomObject interface {
@@ -22,6 +23,13 @@ type BaseCustomObject interface {
 
 // ObjectTransform is an operation that transforms the manifest objects before applying it.
 type ObjectTransform = func(context.Context, BaseCustomObject, *ManifestResources) error
+
+type PostRun = func(
+	ctx context.Context,
+	client client.Client,
+	obj BaseCustomObject,
+	state ResourceLists,
+) error
 
 type State string
 

--- a/pkg/types/installs.go
+++ b/pkg/types/installs.go
@@ -13,16 +13,16 @@ import (
 // ManifestClient offers client utility methods for processing of manifest resources.
 type ManifestClient interface {
 	// GetRawManifest returns processed resource manifest using the client.
-	GetRawManifest(deployInfo InstallInfo) *ParsedFile
+	GetRawManifest(deployInfo *InstallInfo) *ParsedFile
 
 	// Install transforms and applies resources based on InstallInfo.
-	Install(manifest string, deployInfo InstallInfo, transforms []ObjectTransform) (bool, error)
+	Install(manifest string, deployInfo *InstallInfo, transforms []ObjectTransform, postRuns []PostRun) (bool, error)
 
 	// Uninstall transforms and applies resources based on InstallInfo.
-	Uninstall(manifest string, deployInfo InstallInfo, transforms []ObjectTransform) (bool, error)
+	Uninstall(manifest string, deployInfo *InstallInfo, transforms []ObjectTransform, postRuns []PostRun) (bool, error)
 
 	// IsConsistent transforms and checks if resources are consistently installed based on InstallInfo.
-	IsConsistent(manifest string, deployInfo InstallInfo, transforms []ObjectTransform) (bool, error)
+	IsConsistent(manifest string, deployInfo *InstallInfo, transforms []ObjectTransform, postRuns []PostRun) (bool, error)
 
 	// GetCachedResources returns a resource manifest which was already cached during previous operations.
 	// By default, it looks inside <chart-path>/manifest/manifest.yaml
@@ -38,7 +38,7 @@ type ManifestClient interface {
 
 	// InvalidateConfigAndRenderedManifest compares the cached hash with the processed hash for helm flags.
 	// On mismatch, it invalidates the cached manifest and resets flags on client.
-	InvalidateConfigAndRenderedManifest(deployInfo InstallInfo, cachedHash uint32) (uint32, error)
+	InvalidateConfigAndRenderedManifest(deployInfo *InstallInfo, cachedHash uint32) (uint32, error)
 
 	// GetClusterInfo returns Client and REST config for the target cluster
 	GetClusterInfo() (ClusterInfo, error)
@@ -166,9 +166,9 @@ type InstallInfo struct {
 	// ChartInfo represents chart information to be processed
 	*ChartInfo
 	// ResourceInfo represents additional resources to be processed
-	ResourceInfo
+	*ResourceInfo
 	// ClusterInfo represents target cluster information
-	ClusterInfo
+	*ClusterInfo
 	// Ctx hold the current context
 	Ctx context.Context //nolint:containedctx
 	// CheckFn returns a boolean indicating ready state based on custom checks


### PR DESCRIPTION
This sets up post hooks for installations so that potential cleanup work (like removing orphans) can be done from client side. Also it removes various struct copies of InstallInfo which lead to unnecessary copies and memory consumption.