### PR TITLE
fix manifest parser ttl to be regularly cleaned up

### DIFF
--- a/pkg/declarative/v2/inmemory_rendered.go
+++ b/pkg/declarative/v2/inmemory_rendered.go
@@ -18,6 +18,7 @@ type ManifestParser interface {
 
 func NewInMemoryCachedManifestParser(ttl time.Duration) *InMemoryManifestCache {
 	cache := ttlcache.New[string, types.ManifestResources]()
+	go cache.Start()
 	return &InMemoryManifestCache{Cache: cache, TTL: ttl}
 }
 


### PR DESCRIPTION
Parser cache was missing a call to Start which causes all entries to be continuously left in the cache.