### PR TITLE
fix: remote flag default value apply & readiness errs

### DIFF
--- a/api/v1alpha1/manifest_types.go
+++ b/api/v1alpha1/manifest_types.go
@@ -42,8 +42,7 @@ type InstallInfo struct {
 // ManifestSpec defines the specification of Manifest.
 type ManifestSpec struct {
 	// Remote indicates if Manifest should be installed on a remote cluster
-	// +kubebuilder:default:=true
-	Remote bool `json:"remote,omitempty"`
+	Remote bool `json:"remote"`
 
 	// Config specifies OCI image configuration for Manifest
 	Config types.ImageSpec `json:"config,omitempty"`

--- a/config/crd/bases/operator.kyma-project.io_manifests.yaml
+++ b/config/crd/bases/operator.kyma-project.io_manifests.yaml
@@ -46,7 +46,7 @@ spec:
                 description: Config specifies OCI image configuration for Manifest
                 properties:
                   credSecretSelector:
-                    description: CredSecretSelector is on optional field, for OCI
+                    description: CredSecretSelector is an optional field, for OCI
                       image saved in private registry, use it to indicate the secret
                       which contains registry credentials, must exist in the namespace
                       same as manifest
@@ -115,7 +115,7 @@ spec:
                 description: CRDs specifies the custom resource definitions' ImageSpec
                 properties:
                   credSecretSelector:
-                    description: CredSecretSelector is on optional field, for OCI
+                    description: CredSecretSelector is an optional field, for OCI
                       image saved in private registry, use it to indicate the secret
                       which contains registry credentials, must exist in the namespace
                       same as manifest
@@ -199,7 +199,6 @@ spec:
                   type: object
                 type: array
               remote:
-                default: true
                 description: Remote indicates if Manifest should be installed on a
                   remote cluster
                 type: boolean
@@ -211,6 +210,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
             required:
             - installs
+            - remote
             type: object
           status:
             description: Status signifies the current status of the Manifest

--- a/internal/manifest/v1alpha1/ready_check.go
+++ b/internal/manifest/v1alpha1/ready_check.go
@@ -15,7 +15,7 @@ import (
 
 const customResourceStatePath = "status.state"
 
-var ErrCustomResourceNotFound = errors.New("custom resource not found")
+var ErrCustomResourceStateNotFound = errors.New("custom resource state not found")
 
 // NewManifestCustomResourceReadyCheck creates a readiness check that verifies that the Resource in the Manifest
 // returns the ready state, if not it returns not ready.
@@ -33,15 +33,15 @@ func (c *ManifestCustomResourceReadyCheck) Run(
 	if err := clnt.Get(ctx, client.ObjectKeyFromObject(res), res); err != nil {
 		return err
 	}
-	state, found, err := unstructured.NestedString(res.Object, strings.Split(customResourceStatePath, ".")...)
+	state, stateExists, err := unstructured.NestedString(res.Object, strings.Split(customResourceStatePath, ".")...)
 	if err != nil {
 		return fmt.Errorf(
-			"could not get state from custom resource %s at path %s",
+			"could not get state from custom resource %s at path %s to determine readiness",
 			res.GetName(), customResourceStatePath,
 		)
 	}
-	if !found {
-		return ErrCustomResourceNotFound
+	if !stateExists {
+		return ErrCustomResourceStateNotFound
 	}
 
 	if state := declarative.State(state); state != declarative.StateReady {

--- a/pkg/types/installs.go
+++ b/pkg/types/installs.go
@@ -53,7 +53,7 @@ type ImageSpec struct {
 	// Type defines the chart as "oci-ref"
 	Type RefTypeMetadata `json:"type,omitempty"`
 
-	// CredSecretSelector is on optional field, for OCI image saved in private registry,
+	// CredSecretSelector is an optional field, for OCI image saved in private registry,
 	// use it to indicate the secret which contains registry credentials,
 	// must exist in the namespace same as manifest
 	CredSecretSelector *metav1.LabelSelector `json:"credSecretSelector,omitempty"`


### PR DESCRIPTION
This PR fixes the remote flag which had omitempty and thus was omitted for updates if the value was set to "false" in lifecycle manager, thus ignoring the update even if the cluster value was true.

It also adjusts the secret lookup for remote clusters so that the error messages for remote lookup work correctly and are more descriptive if the secret does not exist