### PR TITLE
Dynamic CR delete backoff instead of immediately succeeding

### DIFF
--- a/internal/manifest/v1alpha1/custom_resource.go
+++ b/internal/manifest/v1alpha1/custom_resource.go
@@ -14,7 +14,9 @@ import (
 
 const CustomResourceManager = "resource.kyma-project.io/finalizer"
 
-var ErrWaitingForAsyncCustomResourceDeletion = errors.New("deletion of custom resource was triggered and is now waiting to be completed")
+var ErrWaitingForAsyncCustomResourceDeletion = errors.New(
+	"deletion of custom resource was triggered and is now waiting to be completed",
+)
 
 // PostRunCreateCR is a hook for creating the manifest default custom resource if not available in the cluster
 // It is used to provide the controller with default data in the Runtime.

--- a/pkg/declarative/v2/reconciler.go
+++ b/pkg/declarative/v2/reconciler.go
@@ -294,7 +294,7 @@ func (r *Reconciler) deleteResources(
 		for _, preDelete := range r.PreDeletes {
 			if err := preDelete(ctx, clnt, r.Client, obj); err != nil {
 				r.Event(obj, "Warning", "PreDelete", err.Error())
-				// we do not set a status here since it will be deleting if timestamp is set to zero.
+				// we do not set a status here since it will be deleting if timestamp is set.
 				return err
 			}
 		}


### PR DESCRIPTION
By default we always continued after the deletion trigger of the Custom Resource. By default we used Background Propagation. This lead to the manager immediately being removed without the CR being cleaned properly. This introduces an error if the deletion is triggered successfully and thus forces a requeue in case the deletion is triggered. We do not want ForegroundPropagation here since we would block the reconcile loop which we do not want.

Fix: #212