### PR TITLE
feat: allow nil manifests from CRD to not delete module

### DIFF
--- a/api/v1alpha1/manifest_types.go
+++ b/api/v1alpha1/manifest_types.go
@@ -52,8 +52,9 @@ type ManifestSpec struct {
 
 	//+kubebuilder:pruning:PreserveUnknownFields
 	//+kubebuilder:validation:XEmbeddedResource
+	//+nullable
 	// Resource specifies a resource to be watched for state updates
-	Resource unstructured.Unstructured `json:"resource,omitempty"`
+	Resource *unstructured.Unstructured `json:"resource,omitempty"`
 
 	// CRDs specifies the custom resource definitions' ImageSpec
 	CRDs types.ImageSpec `json:"crds,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -128,7 +128,10 @@ func (in *ManifestSpec) DeepCopyInto(out *ManifestSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	in.Resource.DeepCopyInto(&out.Resource)
+	if in.Resource != nil {
+		in, out := &in.Resource, &out.Resource
+		*out = (*in).DeepCopy()
+	}
 	in.CRDs.DeepCopyInto(&out.CRDs)
 }
 

--- a/config/crd/bases/operator.kyma-project.io_manifests.yaml
+++ b/config/crd/bases/operator.kyma-project.io_manifests.yaml
@@ -205,6 +205,7 @@ spec:
               resource:
                 description: Resource specifies a resource to be watched for state
                   updates
+                nullable: true
                 type: object
                 x-kubernetes-embedded-resource: true
                 x-kubernetes-preserve-unknown-fields: true

--- a/internal/manifest/v1alpha1/custom_resource.go
+++ b/internal/manifest/v1alpha1/custom_resource.go
@@ -24,10 +24,10 @@ func PostRunCreateCR(
 	ctx context.Context, skr declarative.Client, kcp client.Client, obj declarative.Object,
 ) error {
 	manifest := obj.(*manifestv1alpha1.Manifest)
-	resource := manifest.Spec.Resource.DeepCopy()
-	if resource.Object == nil {
+	if manifest.Spec.Resource == nil {
 		return nil
 	}
+	resource := manifest.Spec.Resource.DeepCopy()
 
 	if err := skr.Create(
 		ctx, resource, client.FieldOwner(CustomResourceManager),
@@ -61,10 +61,10 @@ func PreDeleteDeleteCR(
 	ctx context.Context, skr declarative.Client, kcp client.Client, obj declarative.Object,
 ) error {
 	manifest := obj.(*manifestv1alpha1.Manifest)
-	resource := manifest.Spec.Resource.DeepCopy()
-	if resource.Object == nil {
+	if manifest.Spec.Resource == nil {
 		return nil
 	}
+	resource := manifest.Spec.Resource.DeepCopy()
 
 	propagation := v1.DeletePropagationBackground
 	err := skr.Delete(ctx, resource, &client.DeleteOptions{PropagationPolicy: &propagation})

--- a/internal/manifest/v1alpha1/manifest_controller_test.go
+++ b/internal/manifest/v1alpha1/manifest_controller_test.go
@@ -332,7 +332,7 @@ func installManifest(manifest *v1alpha1.Manifest, installSpecByte []byte, crdSpe
 	manifest.Spec.CRDs = crdSpec
 	if remote {
 		manifest.Spec.Remote = true
-		manifest.Spec.Resource = unstructured.Unstructured{
+		manifest.Spec.Resource = &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": "operator.kyma-project.io/v1alpha1",
 				"kind":       "SampleCRD",

--- a/internal/manifest/v1alpha1/ready_check.go
+++ b/internal/manifest/v1alpha1/ready_check.go
@@ -29,6 +29,9 @@ func (c *ManifestCustomResourceReadyCheck) Run(
 	ctx context.Context, clnt declarative.Client, obj declarative.Object, _ []*resource.Info,
 ) error {
 	manifest := obj.(*manifestv1alpha1.Manifest)
+	if manifest.Spec.Resource == nil {
+		return nil
+	}
 	res := manifest.Spec.Resource.DeepCopy()
 	if err := clnt.Get(ctx, client.ObjectKeyFromObject(res), res); err != nil {
 		return err


### PR DESCRIPTION
Allows to pass no Manifest under which circumstances the Custom Resource is not tracked, neither created nor deleted nor checked for readiness.