### PR TITLE
Adapt layout for latest kubebuilder and golang standard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,14 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY main.go main.go
+COPY cmd/main.go cmd/main.go
 COPY api api/
 COPY pkg pkg/
 COPY internal internal/
-COPY controllers controllers/
+COPY internal/controller controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager ./cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,11 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	go build -o bin/manager ./cmd/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go
+	go run ./cmd/main.go
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The Module Manager repository offers the following components:
 | System Component                                          | Stability                                                                                         |
 |-----------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | [Manifest](api/v1alpha1/manifest_types.go)       | Alpha-Grade - do not rely on automation and watch upstream as close as possible                   |
-| [Controller](controllers/manifest_controller.go) | In active development - expect bugs and fast-paced development                                    |
+| [Controller](internal/controllers/manifest_controller.go) | In active development - expect bugs and fast-paced development                                    |
 | [Library](pkg)                                   | In active development - expect bugs and fast-paced development. Detailed documentation to follow. |
 
 ## Operator specification

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ In general, the reconciliation and resource-processing framework is considered s
 
 The Module Manager repository offers the following components:
 
-| System Component                                          | Stability                                                                                         |
-|-----------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| System Component                                         | Stability                                                                                         |
+|----------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | [Manifest](api/v1alpha1/manifest_types.go)       | Alpha-Grade - do not rely on automation and watch upstream as close as possible                   |
-| [Controller](internal/controllers/manifest_controller.go) | In active development - expect bugs and fast-paced development                                    |
+| [Controller](internal/controller/manifest_controller.go) | In active development - expect bugs and fast-paced development                                    |
 | [Library](pkg)                                   | In active development - expect bugs and fast-paced development. Detailed documentation to follow. |
 
 ## Operator specification

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"github.com/kyma-project/module-manager/internal/controller"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -25,7 +26,6 @@ import (
 	"time"
 
 	manifestv1alpha1 "github.com/kyma-project/module-manager/api/v1alpha1"
-	"github.com/kyma-project/module-manager/controllers"
 	"github.com/kyma-project/module-manager/internal"
 	"github.com/kyma-project/module-manager/pkg/labels"
 	"github.com/kyma-project/module-manager/pkg/types"

--- a/internal/controller/manifest_controller.go
+++ b/internal/controller/manifest_controller.go
@@ -2,10 +2,10 @@ package controllers
 
 import (
 	"fmt"
+	internalv1alpha1 "github.com/kyma-project/module-manager/internal/manifest/v1alpha1"
 	"time"
 
 	"github.com/kyma-project/module-manager/api/v1alpha1"
-	internalv1alpha1 "github.com/kyma-project/module-manager/internal/manifest/v1alpha1"
 	declarative "github.com/kyma-project/module-manager/pkg/declarative/v2"
 	"github.com/kyma-project/module-manager/pkg/labels"
 	"github.com/kyma-project/module-manager/pkg/types"
@@ -57,7 +57,7 @@ func ManifestReconciler(
 		),
 		declarative.WithCustomReadyCheck(internalv1alpha1.NewManifestCustomResourceReadyCheck()),
 		declarative.WithRemoteTargetCluster(
-			(&internalv1alpha1.RemoteClusterLookup{KCP: &types.ClusterInfo{
+			(&RemoteClusterLookup{KCP: &types.ClusterInfo{
 				Client: mgr.GetClient(),
 				Config: mgr.GetConfig(),
 			}}).ConfigResolver,

--- a/internal/controller/manifest_controller.go
+++ b/internal/controller/manifest_controller.go
@@ -50,18 +50,15 @@ func ManifestReconciler(
 	mgr manager.Manager, codec *types.Codec, insecure bool,
 	checkInterval time.Duration,
 ) *declarative.Reconciler {
+	rcl := &internalv1alpha1.RemoteClusterLookup{KCP: &types.ClusterInfo{
+		Client: mgr.GetClient(),
+		Config: mgr.GetConfig(),
+	}}
 	return declarative.NewFromManager(
 		mgr, &v1alpha1.Manifest{},
-		declarative.WithSpecResolver(
-			internalv1alpha1.NewManifestSpecResolver(codec, insecure),
-		),
+		declarative.WithSpecResolver(internalv1alpha1.NewManifestSpecResolver(codec, insecure)),
 		declarative.WithCustomReadyCheck(internalv1alpha1.NewManifestCustomResourceReadyCheck()),
-		declarative.WithRemoteTargetCluster(
-			(&RemoteClusterLookup{KCP: &types.ClusterInfo{
-				Client: mgr.GetClient(),
-				Config: mgr.GetConfig(),
-			}}).ConfigResolver,
-		),
+		declarative.WithRemoteTargetCluster(rcl.ConfigResolver),
 		declarative.WithClientCacheKeyFromLabelOrResource(labels.KymaName),
 		declarative.WithPostRun{internalv1alpha1.PostRunCreateCR},
 		declarative.WithPreDelete{internalv1alpha1.PreDeleteDeleteCR},


### PR DESCRIPTION
Changes:

* Move controller directory to internal and rename to singular
* Move main to cmd directory
